### PR TITLE
change SMALLINT to 32767

### DIFF
--- a/mixer/_faker.py
+++ b/mixer/_faker.py
@@ -7,7 +7,7 @@ from faker import Factory, Generator
 from faker.config import DEFAULT_LOCALE, AVAILABLE_LOCALES, PROVIDERS
 from faker.providers import BaseProvider
 
-SMALLINT = 32768  # Safe in most databases according to Django docs
+SMALLINT = 32767  # Safe in most databases according to Django docs
 
 GENRES = ('general', 'pop', 'dance', 'traditional', 'rock', 'alternative', 'rap', 'country',
           'jazz', 'gospel', 'latin', 'reggae', 'comedy', 'historical', 'action', 'animation',


### PR DESCRIPTION
in mysql 32768 is too large for a small int, only 32767 is allowed.
(ref - https://dev.mysql.com/doc/refman/8.0/en/integer-types.html)
this causes a bug for me many times.